### PR TITLE
removed cask from Cask class command method

### DIFF
--- a/lib/infinum_setup/program/cask.rb
+++ b/lib/infinum_setup/program/cask.rb
@@ -6,7 +6,7 @@ module InfinumSetup
       end
 
       def command
-        "brew cask install #{program}"
+        "brew install #{program}"
       end
 
       def program


### PR DESCRIPTION
Infinum script breaks when installing apps (chrome, firefox, ...) because `brew cask` command is integrated in brew so instead using `brew cask install something` we need to use `brew install something`.