### PR TITLE
Add Java setup

### DIFF
--- a/lib/infinum_setup/install.rb
+++ b/lib/infinum_setup/install.rb
@@ -10,7 +10,7 @@ module InfinumSetup
     end
 
     def self.select_team
-      TTY::Prompt.new.select('Select your team', %w{rails javascript android ios design pm other})
+      TTY::Prompt.new.select('Select your team', %w{rails java javascript android ios design pm other})
     end
 
     private

--- a/programs/java.yml
+++ b/programs/java.yml
@@ -1,0 +1,36 @@
+intellij-idea:
+  pre_install_comment: Installs IntelliJ IDEA – the primary IDE for Java development
+  mandatory: true
+  install_if_not_interactive: true
+  type: cask
+  program: intellij-idea
+rancher:
+  pre_install_comment: Used for container orchestration and testing in local dev setup
+  mandatory: true
+  install_if_not_interactive: true
+  type: cask
+  program: rancher
+awscli:
+  pre_install_comment: Installs AWS CLI – used to interact with AWS services from the terminal
+  mandatory: true
+  install_if_not_interactive: true
+  type: brew
+  program: awscli
+jq:
+  pre_install_comment: Installs jq – tool for working with JSON via CLI
+  mandatory: false
+  install_if_not_interactive: true
+  type: brew
+  program: jq
+httpie:
+  pre_install_comment: Installs HTTPie – a user-friendly command-line HTTP client
+  mandatory: false
+  install_if_not_interactive: true
+  type: brew
+  program: httpie
+dbeaver:
+  pre_install_comment: Installs DBeaver – universal database client
+  mandatory: false
+  install_if_not_interactive: true
+  type: cask
+  program: dbeaver-community

--- a/spec/infinum_setup_spec.rb
+++ b/spec/infinum_setup_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe InfinumSetup do
   it 'all programs valid' do
-    [:general, :rails, :design, :android, :ios, :pm, :javascript].each do |team|
+    [:general, :rails, :design, :android, :ios, :pm, :javascript, :java].each do |team|
       InfinumSetup::Base.new(team: team).programs.each do |program|
         expect(program.valid?).to be_truthy
       end


### PR DESCRIPTION
## Summary

Adds the initial `java.yaml` configuration file to support consistent Java team onboarding on macOS. The configuration defines a curated set of tools relevant to Java backend development, categorized by importance and install type.

## Key Additions

- `java.yaml` file with tool definitions
- `mandatory` and `optional` tool classification
- Support for team-wide reuse by exposing the Java team as a selectable group

## Tools Included

| Tool              | Install Type | Mandatory | Description                                             |
|-------------------|--------------|-----------|---------------------------------------------------------|
| intellij-idea     | cask         | Yes       | Primary IDE for Java development                       |
| rancher           | cask         | Yes       | Local Kubernetes and container orchestration           |
| awscli            | brew         | Yes       | CLI for interacting with AWS services                  |
| jq                | brew         | No        | Command-line tool for working with JSON                |
| httpie            | brew         | No        | Developer-friendly HTTP client for API testing         |
| dbeaver-community | cask         | No        | GUI database client for accessing relational databases |

## Motivation

This setup standardizes the local development environment across the Java team, reduces onboarding friction, and avoids tool redundancy. Tools like Maven and Docker were intentionally excluded due to coverage by IntelliJ IDEA and Rancher Desktop.
