### PR TITLE
Add sdkman to Java setup

### DIFF
--- a/programs/java.yml
+++ b/programs/java.yml
@@ -16,6 +16,13 @@ awscli:
   install_if_not_interactive: true
   type: brew
   program: awscli
+sdkman:
+  pre_install_comment: Installs SDKMAN – a tool for managing parallel versions of multiple SDKs (JDK, Maven, Gradle, etc.)
+  mandatory: true
+  install_if_not_interactive: true
+  type: script
+  script: curl -s "https://get.sdkman.io" | bash
+  post_install_comment: After installation, restart your terminal or run 'source "$HOME/.sdkman/bin/sdkman-init.sh"' to start using sdkman
 jq:
   pre_install_comment: Installs jq – tool for working with JSON via CLI
   mandatory: false


### PR DESCRIPTION
## Summary

Adds `sdkman` to the `java.yaml` configuration file used for Java team onboarding on macOS. SDKMAN is included as a mandatory tool to streamline SDK version management during local development setup.

## Key Additions

- `sdkman` installation via shell script
- Marked as `mandatory` in the setup configuration
- Includes pre and post-installation comments for onboarding clarity

## Tools Included

| Tool   | Install Type | Mandatory | Description                                             |
|--------|--------------|-----------|---------------------------------------------------------|
| sdkman | script       | Yes       | Tool for managing parallel versions of JDK, Maven, etc. |

## Motivation

SDKMAN is widely used for managing multiple Java-related SDKs such as different JDK versions, Maven, Gradle, and more. Including it by default reduces setup friction, improves consistency across machines, and supports flexibility in working with different project requirements.
