### PR TITLE
[Task #1162] Resolve CVE-2020-8130

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,9 @@
 source 'https://rubygems.org'
 
+gem 'bundler', '~> 1.12'
+gem 'pry'
+gem 'rake', '~> 12.0'
+gem 'rspec', '~> 3.0'
+
 # Specify your gem's dependencies in infinum_setup.gemspec
 gemspec

--- a/infinum_setup.gemspec
+++ b/infinum_setup.gemspec
@@ -26,12 +26,6 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-
-  spec.add_development_dependency 'bundler', '~> 1.12'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'pry'
-
   spec.add_dependency 'commander', '~> 4.6.0'
   spec.add_dependency 'tty-prompt'
   spec.add_dependency 'tty-which', '~> 0.2'


### PR DESCRIPTION
## Summary

Resolve CVE-2020-8130 by updating version constraint for rake to `~> 12.0`. Development dependencies moved from gemspec to Gemfile.

```bash
root@da4eb73185ca:/usr/src# bundle audit --update
Download ruby-advisory-db ...
Cloning into '/root/.local/share/ruby-advisory-db'...
remote: Enumerating objects: 12622, done.
remote: Counting objects: 100% (15/15), done.
remote: Compressing objects: 100% (10/10), done.
remote: Total 12622 (delta 4), reused 11 (delta 4), pack-reused 12607 (from 1)
Receiving objects: 100% (12622/12622), 2.19 MiB | 3.50 MiB/s, done.
Resolving deltas: 100% (6843/6843), done.
ruby-advisory-db:
  advisories:   1007 advisories
  last updated: 2025-09-01 10:59:23 -0700
  commit:       1be9b4a2a7295fa664b1451fcc147348722d8236
Name: rake
Version: 10.5.0
CVE: CVE-2020-8130
GHSA: GHSA-jppv-gw3r-w3q8
Criticality: High
URL: https://github.com/advisories/GHSA-jppv-gw3r-w3q8
Title: OS Command Injection in Rake
Solution: update to '>= 12.3.3'

Vulnerabilities found!
```