### PR TITLE
[Task #1163] Specify target ruby version

### DIFF
--- a/infinum_setup.gemspec
+++ b/infinum_setup.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
     raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
   end
 
-  required_ruby_version = '>= 2.6.10'
+  spec.required_ruby_version = '>= 2.6.10'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec)/}) }
   spec.bindir        = 'exe'


### PR DESCRIPTION
## Summary

Specify target Ruby version to be 2.6.10 so it matches Ruby version shipped with default macOS. Change contact info to Team Rails.